### PR TITLE
Update check_zfs to fix pool health detection

### DIFF
--- a/check_zfs
+++ b/check_zfs
@@ -26,7 +26,7 @@ sub get_pools() {
     my @ret = split(/\s+/, $_);
     push(@zpool, {
         'name'   => $ret[0],
-        'health' => $ret[8],
+        'health' => $ret[-2],
         'size'   => $ret[1],
         'alloc'  => $ret[2],
         'free'   => $ret[3],

--- a/check_zfs
+++ b/check_zfs
@@ -30,7 +30,7 @@ sub get_pools() {
         'size'   => $ret[1],
         'alloc'  => $ret[2],
         'free'   => $ret[3],
-        'frag'   => $ret[5]
+        'frag'   => $ret[6]
     });
   }
   close(P);


### PR DESCRIPTION
change of pool health detection

Debian Buster and Centos 7.8 added another column to zpool list which broke the health detection. The code is change to read the status from the right side of the string

In Ubuntu 18.04 LTS and Debian Stretch it is:
zfsdata 1.81T   485G    1.34T   -       45%     26%     1.00x   ONLINE  -

In Debian Buster and Centos 7.8 it is:
zfsdata 1.81T   485G    1.34T   -       -       45%     26%     1.00x   ONLINE  -

(originally from @FloMiau committed to macskas/nagios-plugins)